### PR TITLE
feat: godot logger as default

### DIFF
--- a/src/Mirage.Godot/Scripts/Logging/GodotLogger.cs
+++ b/src/Mirage.Godot/Scripts/Logging/GodotLogger.cs
@@ -6,6 +6,11 @@ namespace Mirage
 {
     public class GodotLogger : ILogHandler
     {
+        public GodotLogger()
+        {
+            LogFactory.ReplaceLogHandler(this, true);
+        }
+
         public void LogException(Exception exception)
         {
             LogFormat(LogType.Error, "[Exception] {0}", exception);


### PR DESCRIPTION
replaces the mono standalone logger which does not report to the godot editor