### PR TITLE
Fix warning: Ensure GodotProjectDir is set to avoid build issues

### DIFF
--- a/src/Mirage.Core/Mirage.CodeGen/Mirage.CodeGen.csproj
+++ b/src/Mirage.Core/Mirage.CodeGen/Mirage.CodeGen.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Godot.SourceGenerators" Version="4.3.0" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    <PackageReference Include="GodotSharp" Version="4.3.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Mirage.Core/Mirage.CodeGen/Mirage.CodeGen.csproj
+++ b/src/Mirage.Core/Mirage.CodeGen/Mirage.CodeGen.csproj
@@ -7,6 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Godot.SourceGenerators" Version="4.3.0" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <PackageReference Include="GodotSharp" Version="4.3.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <GodotProjectDir>$(MSBuildProjectDirectory)</GodotProjectDir>
+  </PropertyGroup>
+  
+  <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
   </ItemGroup>
 


### PR DESCRIPTION
This fix addresses a build warning related to the ScriptPathAttributeGenerator in the Godot project. The warning occurred because the GodotProjectDir property was null or empty, which caused the generator to fail in generating necessary source code, potentially leading to compilation errors.

To resolve this issue, the GodotProjectDir property was explicitly set to the project's directory using the $(MSBuildProjectDirectory) macro in the Mirage.CodeGen.csproj file. This ensures that the GodotProjectDir is always correctly defined during the build process, preventing the warning from occurring and allowing for smooth code generation and compilation.

Additionally, the fix includes adding the Godot.SourceGenerators package as an analyzer. This package is essential for managing attributes such as [ScriptPath], [Signal], and [Export] in Godot's C# scripts, as it provides the necessary tools for source generation.T he ReferenceOutputAssembly="false" setting ensures that this package is used only during the build process and not included in the final output assembly.

```CSC : warning CS8785: Generator 'ScriptPathAttributeGenerator' failed to generate source. It will not contribute to
 the output and compilation errors may occur as a result.
  Exception was of type 'InvalidOperationException' with message 'Property 'GodotProjectDir' is null or empty.'. 
[D:\GITHUB\WORK\GODOT\Projects\SingleProjects\Tests\MIrage\Mi
rageRepoTest\Mirage.Godot\src\Mirage.Core\Mirage.CodeGen\Mirage.CodeGen.csproj]
    1 Warning(s)
    0 Error(s)```