### PR TITLE
Fix warning: Ensure GodotProjectDir is set to avoid build issues

### DIFF
--- a/src/Mirage.Core/Mirage.CodeGen/Mirage.CodeGen.csproj
+++ b/src/Mirage.Core/Mirage.CodeGen/Mirage.CodeGen.csproj
@@ -7,6 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Godot.SourceGenerators" Version="4.3.0" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <GodotProjectDir>$(MSBuildProjectDirectory)</GodotProjectDir>
+  </PropertyGroup>
+  
+  <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
   </ItemGroup>
 

--- a/src/Mirage.Godot.Example1/Example2d/Prefabs/Cube2d.tscn
+++ b/src/Mirage.Godot.Example1/Example2d/Prefabs/Cube2d.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://cvi6cc3gurby7"]
 
 [ext_resource type="Script" path="res://Mirage.Godot/Objects/NetworkIdentity.cs" id="1_wcfy5"]
-[ext_resource type="Script" path="res://NetworkPositionSync/SyncPositionBehaviour.cs" id="2_g8o2c"]
+[ext_resource type="Script" path="res://Scripts/NetworkPositionSync/SyncPositionBehaviour.cs" id="2_g8o2c"]
 [ext_resource type="Script" path="res://Example2d/Scripts/MoveCube2d.cs" id="3_iadf8"]
 
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_gdggc"]

--- a/src/Mirage.Godot.Example1/Example2d/Prefabs/Player2d.tscn
+++ b/src/Mirage.Godot.Example1/Example2d/Prefabs/Player2d.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://bg0p7ddm0edm"]
 
 [ext_resource type="Script" path="res://Mirage.Godot/Objects/NetworkIdentity.cs" id="1_ivcl6"]
-[ext_resource type="Script" path="res://NetworkPositionSync/SyncPositionBehaviour.cs" id="2_guhnv"]
+[ext_resource type="Script" path="res://Scripts/NetworkPositionSync/SyncPositionBehaviour.cs" id="2_guhnv"]
 [ext_resource type="Script" path="res://Example2d/Scripts/MovePlayer2d.cs" id="3_c5717"]
 
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_f5svo"]

--- a/src/Mirage.Godot.Example1/Example2d/Scenes/World2d.tscn
+++ b/src/Mirage.Godot.Example1/Example2d/Scenes/World2d.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=7 format=3 uid="uid://caun6vmr2vpnf"]
 
 [ext_resource type="PackedScene" uid="uid://miuh5bbud7ui" path="res://Prefabs/network_manager.tscn" id="1_0pplq"]
-[ext_resource type="Script" path="res://NetworkPositionSync/SyncPositionSystem.cs" id="2_g7qd7"]
+[ext_resource type="Script" path="res://Scripts/NetworkPositionSync/SyncPositionSystem.cs" id="2_g7qd7"]
 [ext_resource type="Script" path="res://Example2d/Scripts/Manager2d.cs" id="3_fm2wy"]
 [ext_resource type="PackedScene" uid="uid://bg0p7ddm0edm" path="res://Example2d/Prefabs/Player2d.tscn" id="4_6omh3"]
 [ext_resource type="PackedScene" uid="uid://cvi6cc3gurby7" path="res://Example2d/Prefabs/Cube2d.tscn" id="5_ylfgy"]
@@ -33,9 +33,9 @@ Server = NodePath("../NetworkServer")
 
 [node name="Manager2d" type="Node" parent="NetworkManager" node_paths=PackedStringArray("NetworkManager")]
 script = ExtResource("3_fm2wy")
+NetworkManager = NodePath("..")
 playerPrefab = ExtResource("4_6omh3")
 cubePrefab = ExtResource("5_ylfgy")
-NetworkManager = NodePath("..")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 


### PR DESCRIPTION
This fix addresses a build warning related to the ScriptPathAttributeGenerator in the Godot project. The warning occurred because the GodotProjectDir property was null or empty, which caused the generator to fail in generating necessary source code, potentially leading to compilation errors.

To resolve this issue, the GodotProjectDir property was explicitly set to the project's directory using the $(MSBuildProjectDirectory) macro in the Mirage.CodeGen.csproj file. This ensures that the GodotProjectDir is always correctly defined during the build process, preventing the warning from occurring and allowing for smooth code generation and compilation.

Additionally, the fix includes adding the Godot.SourceGenerators package as an analyzer. This package is essential for managing attributes such as [ScriptPath], [Signal], and [Export] in Godot's C# scripts, as it provides the necessary tools for source generation.T he ReferenceOutputAssembly="false" setting ensures that this package is used only during the build process and not included in the final output assembly.

CSC : warning CS8785: Generator 'ScriptPathAttributeGenerator' failed to generate source. It will not contribute to
 the output and compilation errors may occur as a result. Exception was of type 'InvalidOperationException' with me
ssage 'Property 'GodotProjectDir' is null or empty.'. Mirage.CodeGen.csproj

Also fixed the location in the .tscn files for the NetworkPositionSync directory.